### PR TITLE
 Change to setuptools 38+ format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,18 +47,18 @@ setup_args = {
     'entry_points': {'console_scripts':
           ['mdsrv = mdsrv:entry_point',]
     },
-    'setup_requires': {
-        "cython": ["cython"],
-        "numpy": ["numpy"],
-        "scipy": ["scipy"],
-        "setuptools": ["setuptools"],
+    'setup_requires': [
+        "cython",
+        "numpy",
+        "scipy",
+        "setuptools",
         
-    },
-    'install_requires': {
-        "flask": ["flask"],
-        "mdtraj": ["mdtraj"],
+    ],
+    'install_requires': [
+        "flask",
+        "mdtraj",
 
-    },
+    ],
     'extra_requires': {
         "mdanalysis;platform_system!='Windows' and python_version<'3.4'": ["mdanalysis"],
     },

--- a/setup.py
+++ b/setup.py
@@ -52,9 +52,10 @@ setup_args = {
         "numpy": ["numpy"],
         "scipy": ["scipy"],
         "setuptools": ["setuptools"],
-        "flask": ["flask"],
+        
     },
     'install_requires': {
+        "flask": ["flask"],
         "mdtraj": ["mdtraj"],
 
     },


### PR DESCRIPTION
setuptools 38+ refuses to work if setup_requires or install_requires is a dictionary instead of a list of strings